### PR TITLE
Rewrite payments to use Stripe API instead of custom form

### DIFF
--- a/src/tickets/forms.py
+++ b/src/tickets/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.core.validators import RegexValidator
 from .models import Ticket, Comment
 
 
@@ -37,31 +38,3 @@ class CommentForm(forms.ModelForm):
         fields = [
             "comment_text"
         ]
-
-class PaymentForm(forms.Form):
-    """ Displays the Payment form """
-
-    MONTH_CHOICES = [(i, i) for i in range(1, 13)]
-    YEAR_CHOICES = [(i, i) for i in range(2019, 2030)]
-
-    credit_card_number = forms.CharField(
-        label="Credit Card Number",
-        required=False
-    )
-    cvv = forms.CharField(
-        label="Card CVV",
-        required=False
-        )
-    expiry_month = forms.ChoiceField(
-        label="Month",
-        choices=MONTH_CHOICES,
-        required=False
-    )
-    expiry_year = forms.ChoiceField(
-        label="Year",
-        choices=YEAR_CHOICES,
-        required=False
-    )
-    stripe_id = forms.CharField(
-        widget=forms.HiddenInput
-    )

--- a/src/tickets/models.py
+++ b/src/tickets/models.py
@@ -85,4 +85,4 @@ class Upvote(models.Model):
     )
 
     def __str__(self):
-        return "BU#{0} on Ticket#{1}".format(self.id, self.ticket)
+        return "Upvote #{0} on Ticket {1}".format(self.id, self.ticket)

--- a/src/tickets/templates/new_feature.html
+++ b/src/tickets/templates/new_feature.html
@@ -12,10 +12,7 @@
             <div class="card-content">
                 <h2 class="center">Feature Request</h2>
                 <h3 class="center">There is a €100 fee to make a feature request</h3>
-                <div id="credit-card-errors" style="display: none;">
-                    <div class="alert-message block-message error" id="stripe-error-message"></div>
-                </div>
-                <form id="feature-pay" method="post" enctype="multipart/form-data">
+                <form id="payment-form" method="post" action="{% url 'new_feature' %}" data-token="{{ publishable }}">
                     {% csrf_token %}
                     <div class="row">
                         <div class="col s12">
@@ -23,34 +20,15 @@
                         </div>
                     </div>
                     <h5>Payment Details</h5>
+                    <!-- stripe element will be inserted in this div -->
                     <div class="row">
-                        <div class="col s8">
-                            {{ payment_form.stripe_id }}
-                            <label for="credit_card_number">Credit Card Number</label>
-                            {{ payment_form.credit_card_number }}
-                        </div>
-                        <div class="col s4">
-                            <label for="cvv">CVV</label>
-                            {{ payment_form.cvv }}
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col s12 m6">
-                            <label for="expiry_month">Month</label>
-                            {{ payment_form.expiry_month }}
-                        </div>
-                        <div class="col s12 m6">
-                            <label for="expiry_year">Year</label>
-                            {{ payment_form.expiry_year }}
-                        </div>
+                        <label for="card-element">Credit or Debit card</label>
+                        <div id="card-element"></div>
+                        <div id="card-errors" role="alert"></div>
                     </div>
                     <br><br>
-                    <div class="row">
-                        <div class="col s12 center">
-                            <button type="submit" class="btn deep-purple darken-1">Submit & Pay</button>
-                            <a href="{% url 'all_tickets' %}" class="btn red darken-4">Cancel</a>
-                        </div>
-                    </div>
+                    <button type="submit" class="btn deep-purple darken-1">Submit Payment</button>
+                    <a href="{% url 'all_tickets' %}" class="btn red darken-4">Cancel</a>
                 </form>
             </div>
         </div>
@@ -59,11 +37,6 @@
 {% endblock %}
 
 {% block page_js %}
-<script src="https://js.stripe.com/v2/"></script>
-<script>
-    //<![CDATA[
-    Stripe.publishableKey = '{{ publishable }}';
-    //]]>
-</script>
+<script src="https://js.stripe.com/v3/"></script>
 <script src="{% static 'js/stripe.js' %}"></script>
 {% endblock %}

--- a/src/tickets/templates/ticket_detail.html
+++ b/src/tickets/templates/ticket_detail.html
@@ -58,37 +58,18 @@
     <div class="modal-content">
         <h3 class="center">Upvote Feature</h3>
         <h4 class="center">There is a €5 fee to upvote a Feature</h4>
-        <form id="feature-pay" method="post" action="{% url 'upvote' ticket.id %}">
+        <form id="payment-form" method="post" action="{% url 'upvote' ticket.id %}" data-token="{{ publishable }}">
             {% csrf_token %}
             <h5>Payment Details</h5>
+            <!-- stripe element will be inserted in this div -->
             <div class="row">
-                <div class="col s8">
-                    {{ payment_form.stripe_id }}
-                    <label for="credit_card_number">Credit Card Number</label>
-                    {{ payment_form.credit_card_number }}
-                </div>
-                <div class="col s4">
-                    <label for="cvv">CVV</label>
-                    {{ payment_form.cvv }}
-                </div>
-            </div>
-            <div class="row">
-                <div class="col s12 m6">
-                    <label for="expiry_month">Month</label>
-                    {{ payment_form.expiry_month }}
-                </div>
-                <div class="col s12 m6">
-                    <label for="expiry_year">Year</label>
-                    {{ payment_form.expiry_year }}
-                </div>
+                <label for="card-element">Credit or Debit card</label>
+                <div id="card-element"></div>
+                <div id="card-errors" role="alert"></div>
             </div>
             <br><br>
-            <div class="row">
-                <div class="col s12 center">
-                    <button type="submit" class="btn deep-purple darken-1">Upvote & Pay</button>
-                    <a href="#" class="btn modal-close red darken-4">Cancel</a>
-                </div>
-            </div>
+            <button type="submit" class="btn deep-purple darken-1">Submit Payment</button>
+            <a href="{% url 'all_tickets' %}" class="btn red darken-4">Cancel</a>
         </form>
     </div>
 </div>
@@ -99,11 +80,6 @@
 {% endblock %}
 
 {% block page_js %}
-<script src="https://js.stripe.com/v2/"></script>
-<script>
-    //<![CDATA[
-    Stripe.publishableKey = '{{ publishable }}';
-    //]]>
-</script>
+<script src="https://js.stripe.com/v3/"></script>
 <script src="{% static 'js/stripe.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Removed the PaymentForm form template and implemented Stripe's
own JS to create a payment field that takes the card number,
expiry, and CVV in one line. Field also fully validates the card
type and number length.